### PR TITLE
00015775_emailfolder_part_2_1

### DIFF
--- a/src/routes/unlocked-packages/create-snapshot/helper.js
+++ b/src/routes/unlocked-packages/create-snapshot/helper.js
@@ -165,6 +165,7 @@ function createComponents(packageTypeMap, type, packageName) {
       });
     });
   }
+
   return packageTypeMap;
 }
 
@@ -230,6 +231,7 @@ function mergeComponentsWithMetadataInfo(metadataInfoMap, packageMap, log) {
           }
         });
       });
+
       resolve(packageMap);
       log.log('End Merge Components With MetadataInfo');
     } catch (e) {

--- a/src/routes/unlocked-packages/create-snapshot/helper.js
+++ b/src/routes/unlocked-packages/create-snapshot/helper.js
@@ -165,7 +165,6 @@ function createComponents(packageTypeMap, type, packageName) {
       });
     });
   }
-
   return packageTypeMap;
 }
 
@@ -231,7 +230,6 @@ function mergeComponentsWithMetadataInfo(metadataInfoMap, packageMap, log) {
           }
         });
       });
-
       resolve(packageMap);
       log.log('End Merge Components With MetadataInfo');
     } catch (e) {

--- a/src/routes/unlocked-packages/create-snapshot/metadataTypeParser.js
+++ b/src/routes/unlocked-packages/create-snapshot/metadataTypeParser.js
@@ -267,7 +267,7 @@ class MetadataTypeParser {
       this.zip.addLocalFile(folderXMLPath, folderType);   //  folderXML add to ZIP component
       component.componentType = this.folderTypeToComponentNameMap[folderType];
       component.label = `${folderType}/${component.name}`;
-      component.apiName = (component.name).substring(0, (component.name).length - 9);
+      component.apiName = (component.name).substring(0, (component.name).length - 9);   //  minus '-meta.xml'
       this.componentList.push(component);   //  add folder definitions for Metadata_Item__c
       count++;
     }

--- a/src/routes/unlocked-packages/create-snapshot/metadataTypeParser.js
+++ b/src/routes/unlocked-packages/create-snapshot/metadataTypeParser.js
@@ -263,14 +263,17 @@ class MetadataTypeParser {
       if (!component.name.includes('-meta.xml')) {
         continue;
       }
+
       const folderXMLPath = `${this.projectPath}/${this.packageName}/${folderType}/${component.name}`;
       this.zip.addLocalFile(folderXMLPath, folderType);   //  folderXML add to ZIP component
+
       component.componentType = this.folderTypeToComponentNameMap[folderType];
       component.label = `${folderType}/${component.name}`;
       component.apiName = (component.name).substring(0, (component.name).length - 9);   //  minus '-meta.xml'
       this.componentList.push(component);   //  add folder definitions for Metadata_Item__c
       count++;
     }
+
     if (count > 0) {
       this.log.log(`Component Type: ${this.folderTypeToComponentNameMap[folderType]}, count: ${count}`);
     }


### PR DESCRIPTION
00015775_emailfolder_part_2_1
At SF
we will create additional Metadata_Item__c records
for EmailFolder (classic only)
"No. of Metadata Items" in snapshot will be increased
Metadata_Item__c records will be increased.

Unlocked packages does not support Lightning email templates
So it means they can not have "EmailTemplateFolders" in unlocked package.
(limitation from Salesforce)
